### PR TITLE
make empty form value translate to empty string (not 0)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/src/utilities/convertValue.ts
+++ b/src/utilities/convertValue.ts
@@ -13,6 +13,8 @@ export function convertValue(value: any): number | boolean | string {
 
     if (value === "false") return false;
 
+    if (value === "") return "";
+
     if (!isNaN(+value)) return +value;
 
     return value;

--- a/tests/utilities/convertValue.test.ts
+++ b/tests/utilities/convertValue.test.ts
@@ -11,6 +11,17 @@ Deno.test("convertValue - Number string converts to number", () => {
     assert(!isNaN(+actualValue));
 });
 
+Deno.test("convertValue - Empty string converts to empty string", () => {
+    // Assign
+    const value = "";
+
+    // Act
+    const actualValue = convertValue(value);
+
+    // Assert
+    assert(actualValue === "");
+});
+
 Deno.test("convertValue - Fractal string does not convert to number", () => {
     // Assign
     const value = "1/5";


### PR DESCRIPTION
Before this patch empty form values were converted to `0`. This was because values were coerced to a number with `+value`, and `+"" === 0`.  This commit adds an explicit check for `value === ""`.

In the future, it might be better to return `null` when the key is present, but there is no value.